### PR TITLE
Update to constant_terms() in constraints.py

### DIFF
--- a/src/pyoframe/constraints.py
+++ b/src/pyoframe/constraints.py
@@ -381,7 +381,7 @@ class Expression(Expressionable, FrameWrapper):
         if dims:
             return constant_terms.join(
                 self.data.select(dims).unique(), on=dims, how="outer_coalesce"
-            ).fill_null(0.0)
+            ).with_columns(pl.col(COEF_KEY).fill_null(0.0))
         else:
             if len(constant_terms) == 0:
                 return pl.DataFrame(


### PR DESCRIPTION
Original code caused the constant-term-part of the Expression to change the dtype of columns due to .fill_null(0.0) being applied to the whole dataframe. 

The implemented change applies .fill_null(0.0) only to the column corresponding to the coefficients.
